### PR TITLE
Handle finding statemachine after its initialstate better

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 ##                      http://www.boost.org/LICENSE_1_0.txt)
 ##
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(bosce CXX)
 
 enable_testing()
@@ -32,7 +32,7 @@ add_executable(bosce
 target_link_libraries(bosce
   PUBLIC
     Qt5::Core
-    ${Boost_LIBRARIES}
+    Boost::program_options
 )
 
 add_subdirectory(test)

--- a/src/ScModel.cpp
+++ b/src/ScModel.cpp
@@ -4,9 +4,7 @@ const ScName ScModel::RootScName = "[root]";
 
 void ScModel::addStateMachine(const ScName &name, const ScName &initialState)
 {
-    if (!m_states.contains(name)) {
-        addState(name, RootScName, 0, {initialState});
-    }
+    addState(name, RootScName, 0, {initialState});
 }
 
 void ScModel::addState(const ScName &name, const ScName &parent, int orthRegion,


### PR DESCRIPTION
First commit just includes including the include directory of boost in the include path of cmake. If you have a boost installation which is not in the standard include path this is necessary.

Second commit handles the case when an initial state machine state is encountered and added before its state machine is encountered and added, which would cause the state machine to not be a child of the root note and have no initial state causing it to not be listed as a state machine and the state machine graph being disjointed as the initial state was empty.