### PR TITLE
Handle non-const& events passed to react() methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,9 @@ find_package(Boost REQUIRED COMPONENTS program_options filesystem)
 find_package(Threads REQUIRED)
 
 include(GNUInstallDirs)
-include(cmake/CompilerFlags.cmake)
+include(cmake/AddressSanitizer.cmake)
 include(cmake/ClangTidy.cmake)
+include(cmake/CompilerFlags.cmake)
 
 add_executable(bosce
     src/main.cpp

--- a/cmake/AddressSanitizer.cmake
+++ b/cmake/AddressSanitizer.cmake
@@ -1,0 +1,13 @@
+##
+## Boost StateChart Extractor
+##
+## Distributed under the Boost Software License, Version 1.0.
+## (See accompanying file LICENSE or copy at
+##                      http://www.boost.org/LICENSE_1_0.txt)
+##
+
+set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+set(CMAKE_EXE_LINKER_FLAGS_ASAN "${CMAKE_EXE_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN "${CMAKE_SHARED_LINKER_FLAGS_DEBUG}")
+set(CMAKE_STATIC_LINKER_FLAGS_ASAN "${CMAKE_STATIC_LINKER_FLAGS_DEBUG}")

--- a/src/ScParser.cpp
+++ b/src/ScParser.cpp
@@ -327,7 +327,17 @@ bool ScParser::parseReactMethod(char *&data)
     }
 
     m_currentState = function;
-    m_currentEvent = matchName(data, ' ');
+
+    char *eventName = matchName(data, ' ');
+    if (eventName == nullptr) {
+        /* Sometimes events are not passed as const&.
+         * *state*::react(*event*) */
+        eventName = matchName(data, ')');
+        if (eventName == nullptr) {
+            return false;
+        }
+    }
+    m_currentEvent = eventName;
     if (m_currentEvent.empty()) {
         return false;
     }


### PR DESCRIPTION
Sometimes custom reactions accept events by value. This currently leads to a crash. This PR fixes the issue.